### PR TITLE
chore: require manual approval for Renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,9 @@
   "extends": ["config:base"],
   "dependencyDashboard": true,
   "dependencyDashboardApproval": true,
-  "lockFileMaintenance": { "enabled": true },
+  "lockFileMaintenance": {
+    "enabled": true
+  },
   "labels": ["renovate"],
   "transitiveRemediation": true,
   "platform": "github",
@@ -64,5 +66,6 @@
       "matchPackagePatterns": ["^eslint"],
       "enabled": false
     }
-  ]
+  ],
+  "prCreation": "approval"
 }


### PR DESCRIPTION
### Motivation
- Prevent Renovate from opening update PRs automatically and require human approval via the dependency dashboard.

### Description
- Add `"prCreation": "approval"` to `renovate.json` to require manual approval before creating PRs.
- Reformat the `lockFileMaintenance` object in `renovate.json` for readability with no behavioral change.

### Testing
- Validated `renovate.json` is well-formed JSON with `jq` using `jq . renovate.json >/dev/null`, which exited successfully.
- Confirmed `dependencyDashboardApproval` remains enabled in the resulting configuration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989c7a23cb08326bc73963595058d71)